### PR TITLE
Added Altair GraphQL Client to GraphQL tools list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -233,3 +233,7 @@ Pull requests adding either experimental or mature implementations to these list
 - [rebing/graphql-laravel](https://github.com/rebing/graphql-laravel) (PHP: [Composer](https://packagist.org/packages/rebing/graphql-laravel))
 - [lmcgartland/graphene-file-upload](https://github.com/lmcgartland/graphene-file-upload) (Python: [PyPi](https://pypi.org/project/graphene-file-upload))
 - [jpascal/graphql-upload](https://github.com/jpascal/graphql-upload) (Go: [GitHub](https://github.com/jpascal/graphql-upload))
+
+### GraphQL Tools
+
+- [Altair GraphQL Client](https://altair.sirmuel.design/) [[Usage](https://sirmuel.design/working-with-file-uploads-using-altair-graphql-d2f86dc8261f)]

--- a/readme.md
+++ b/readme.md
@@ -221,6 +221,7 @@ Pull requests adding either experimental or mature implementations to these list
 - [jaydenseric/apollo-upload-client](https://github.com/jaydenseric/apollo-upload-client) (JS: [npm](https://npm.im/apollo-upload-client))
 - [jaydenseric/extract-files](https://github.com/jaydenseric/extract-files) (JS: [npm](https://npm.im/extract-files))
 - [klis87/redux-saga-requests-graphql](https://github.com/klis87/redux-saga-requests/tree/master/packages/redux-saga-requests-graphql) (JS: [npm](https://npm.im/redux-saga-requests-graphql))
+- [imolorhe/altair](https://github.com/imolorhe/altair) (JS: [npm](https://npm.im/altair-static))
 - [~~apollo-fetch-upload~~](https://github.com/apollographql/apollo-fetch/tree/master/packages/apollo-fetch-upload) (JS: [npm](https://npm.im/apollo-fetch-upload))
 
 ### Server
@@ -233,7 +234,3 @@ Pull requests adding either experimental or mature implementations to these list
 - [rebing/graphql-laravel](https://github.com/rebing/graphql-laravel) (PHP: [Composer](https://packagist.org/packages/rebing/graphql-laravel))
 - [lmcgartland/graphene-file-upload](https://github.com/lmcgartland/graphene-file-upload) (Python: [PyPi](https://pypi.org/project/graphene-file-upload))
 - [jpascal/graphql-upload](https://github.com/jpascal/graphql-upload) (Go: [GitHub](https://github.com/jpascal/graphql-upload))
-
-### GraphQL Tools
-
-- [Altair GraphQL Client](https://altair.sirmuel.design/) [[Usage](https://sirmuel.design/working-with-file-uploads-using-altair-graphql-d2f86dc8261f)]


### PR DESCRIPTION
Added a new section for GraphQL tools that support the multipart request spec, and added [Altair](https://altair.sirmuel.design/) to the list.