### PR TITLE
Fix incorrect mutation names in examples

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,7 @@ So operations can be resolved while the files are still uploading, the fields ar
 {
   query: `
     mutation($file: Upload!) {
-      uploadFile(file: $file) {
+      singleUpload(file: $file) {
         id
       }
     }

--- a/readme.md
+++ b/readme.md
@@ -141,7 +141,7 @@ Charlie file content.
   {
     query: `
       mutation($file: Upload!) {
-        uploadFile(file: $file) {
+        singleUpload(file: $file) {
           id
         }
       }


### PR DESCRIPTION
mutation name and curl requested mutation name look inconsistent.
So I made the mutation name to match the curl requested name.