### PR TITLE
Add graphql-upload-minimal to the Server implementations list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -233,6 +233,7 @@ Pull requests adding either experimental or mature implementations to these list
 ### Server
 
 - [jaydenseric/graphql-upload](https://github.com/jaydenseric/graphql-upload) (JS: [npm](https://npm.im/graphql-upload))
+- [koresar/graphql-upload-minimal](https://github.com/koresar/graphql-upload-minimal) (JS: [npm](https://npm.im/graphql-upload-minimal))
 - [apollographql/apollo-server](https://github.com/apollographql/apollo-server) (JS: [npm](https://npm.im/apollo-server))
 - [~~jaydenseric/apollo-upload-server~~](https://github.com/jaydenseric/apollo-upload-server) (JS: [npm](https://npm.im/apollo-upload-server))
 - [99designs/gqlgen](https://github.com/99designs/gqlgen) (Go: [GitHub](https://github.com/99designs/gqlgen))


### PR DESCRIPTION
Hello @jaydenseric 

Thanks for the spec and the libraries. We've forked your top notch `graphql-upload` and adjusted it to our needs. Namely, we had to remove `fs-capacitor` because of security reasons.

Hopefully, someone else would find npm.im/graphql-upload-minimal useful.

Please, accept the PR.