### PR TITLE
Add ChilliCream/hotchocolate to the list of Server-side implementations

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -249,3 +249,4 @@ Pull requests adding either experimental or mature implementations to these list
 - [infinityloop-dev/graphpinator](https://github.com/infinityloop-dev/graphpinator) (PHP: [Composer](https://packagist.org/packages/infinityloop-dev/graphpinator))
 - [lmcgartland/graphene-file-upload](https://github.com/lmcgartland/graphene-file-upload) (Python: [PyPi](https://pypi.org/project/graphene-file-upload))
 - [graphql-java-kickstart/graphql-java-servlet](https://github.com/graphql-java-kickstart/graphql-java-servlet) (Java: [Maven](https://mvnrepository.com/artifact/com.graphql-java/graphql-java-servlet))
+- [ChilliCream/hotchocolate](https://github.com/ChilliCream/hotchocolate) (C#: [NuGet](https://www.nuget.org/packages/HotChocolate))


### PR DESCRIPTION
Support for this specification has been implemented into [ChilliCream/hotchocolate](https://github.com/ChilliCream/hotchocolate) and will be shipped starting with version 11.1.0.