### PR TITLE
Added Altair GraphQL IDE to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -257,3 +257,7 @@ Pull requests adding either experimental or mature implementations to these list
 - [graphql-java-kickstart/graphql-java-servlet](https://github.com/graphql-java-kickstart/graphql-java-servlet) (Java: [Maven](https://mvnrepository.com/artifact/com.graphql-java/graphql-java-servlet))
 - [ChilliCream/hotchocolate](https://github.com/ChilliCream/hotchocolate) (C#: [NuGet](https://www.nuget.org/packages/HotChocolate))
 - [async-graphql/async-graphql](https://github.com/async-graphql/async-graphql) (Rust: [Crates](https://crates.io/crates/async-graphql))
+
+### IDE/Tools
+
+- [Altair GraphQL](https://www.altairgraphql.dev/)


### PR DESCRIPTION
[Altair GraphQL](https://www.altairgraphql.dev/) doesn't exactly fit into either of the existing client/server categories (it's not a server implementation. Adding it to the client list will be confusing since it is different from your typical GQL clients used to make GQL requests and is misleading). Happy to hear your thoughts, if you think otherwise