### PR TITLE
Add Cosmo Router.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -257,3 +257,7 @@ Pull requests adding either experimental or mature implementations to these list
 - [graphql-java-kickstart/graphql-java-servlet](https://github.com/graphql-java-kickstart/graphql-java-servlet) (Java: [Maven](https://mvnrepository.com/artifact/com.graphql-java/graphql-java-servlet))
 - [ChilliCream/hotchocolate](https://github.com/ChilliCream/hotchocolate) (C#: [NuGet](https://www.nuget.org/packages/HotChocolate))
 - [async-graphql/async-graphql](https://github.com/async-graphql/async-graphql) (Rust: [Crates](https://crates.io/crates/async-graphql))
+
+### Router / Gateway
+
+- [wundergraph/cosmo](https://github.com/wundergraph/cosmo)


### PR DESCRIPTION
Adds a new section to the Readme (Router/Gateway) to list Gateways/Routers supporting this specification.

A router will accept client requests following the spec and will then add the files to subgraph requests following the spec again. As a result, files are being piped from client to subgraph through the router.