### PR TITLE
Add go-graphql-client

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -230,13 +230,13 @@ Pull requests adding either experimental or mature implementations to these list
 - [haffdata/buoy](https://github.com/haffdata/buoy) (JS: [npm](https://npm.im/@buoy/client))
 - [FormidableLabs/urql](https://github.com/FormidableLabs/urql) (JS: [npm](https://npm.im/@urql/exchange-multipart-fetch))
 - [~~apollo-fetch-upload~~](https://github.com/apollographql/apollo-fetch/tree/master/packages/apollo-fetch-upload) (JS: [npm](https://npm.im/apollo-fetch-upload))
+- [GnRlLeclerc/go-graphql-client](https://github.com/GnRlLeclerc/go-graphql-client) (Go: [GitHub](https://github.com/GnRlLeclerc/go-graphql-client))
 - [apollographql/apollo-ios](https://github.com/apollographql/apollo-ios) (Swift: [CocoaPods](https://cocoapods.org/pods/Apollo))
 - [apollographql/apollo-android](https://github.com/apollographql/apollo-android) (Java: [Bintray](https://bintray.com/apollographql/android))
 - [zino-app/graphql-flutter](https://github.com/zino-app/graphql-flutter) (Dart: [Pub](https://pub.dev/packages/graphql))
 - [samirelanduk/kirjava](https://github.com/samirelanduk/kirjava) (Python: [PyPi](https://pypi.org/project/kirjava))
 - [DoctorJohn/aiogqlc](https://github.com/DoctorJohn/aiogqlc) (Python: [PyPi](https://pypi.org/project/aiogqlc))
 - [graphql-python/gql](https://github.com/graphql-python/gql) (Python: [PyPi](https://pypi.org/project/gql))
-- [GnRlLeclerc/go-graphql-client](https://github.com/GnRlLeclerc/go-graphql-client) (Go: [GitHub](https://github.com/GnRlLeclerc/go-graphql-client))
 
 ### Server
 

--- a/readme.md
+++ b/readme.md
@@ -236,6 +236,7 @@ Pull requests adding either experimental or mature implementations to these list
 - [samirelanduk/kirjava](https://github.com/samirelanduk/kirjava) (Python: [PyPi](https://pypi.org/project/kirjava))
 - [DoctorJohn/aiogqlc](https://github.com/DoctorJohn/aiogqlc) (Python: [PyPi](https://pypi.org/project/aiogqlc))
 - [graphql-python/gql](https://github.com/graphql-python/gql) (Python: [PyPi](https://pypi.org/project/gql))
+- [GnRlLeclerc/go-graphql-client](https://github.com/GnRlLeclerc/go-graphql-client) (Go: [GitHub](https://github.com/GnRlLeclerc/go-graphql-client))
 
 ### Server
 


### PR DESCRIPTION
Add [go-graphql-client](https://github.com/GnRlLeclerc/go-graphql-client) (inspired from the simple but abandoned https://github.com/machinebox/graphql) which implements the spec. I did not find any GraphQL clients for Go that support multipart file upload, so I made this one (the goal being to integrate with a go gqlgen backend for endpoint tests).